### PR TITLE
Fix/fm 4450 fix barcodescanner crash

### DIFF
--- a/materialbarcodescanner/build.gradle
+++ b/materialbarcodescanner/build.gradle
@@ -33,12 +33,12 @@ android {
 
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'org.greenrobot:eventbus:3.1.1'
-    compile 'androidx.appcompat:appcompat:1.0.0'
-    compile 'com.google.android.gms:play-services-vision:17.0.2'
-    compile ("com.google.android.material:material:1.0.0") {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'org.greenrobot:eventbus:3.1.1'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    api 'com.google.android.gms:play-services-vision:20.1.2'
+    implementation ("com.google.android.material:material:1.0.0") {
         exclude group: "com.google.guava", module: "listenablefuture"
     }
 }

--- a/materialbarcodescanner/src/main/java/com/edwardvanraak/materialbarcodescanner/CameraSource.java
+++ b/materialbarcodescanner/src/main/java/com/edwardvanraak/materialbarcodescanner/CameraSource.java
@@ -1088,9 +1088,7 @@ public class CameraSource {
          * Releases the underlying receiver.  This is only safe to do after the associated thread
          * has completed, which is managed in camera source's release method above.
          */
-        @SuppressLint("Assert")
         void release() {
-            assert (mProcessingThread.getState() == State.TERMINATED);
             mDetector.release();
             mDetector = null;
         }


### PR DESCRIPTION
The crash regarding the Barcode screen was due to the `assert` keyword used in `CameraSource.java`.
By default, the assertion check is disabled by the Android compiler, however, starting AGP 4.1, it will be enabled for the debug version of the application:

> When you build the debug version of your app using Android Gradle plugin 4.1.0 and higher, the built-in compiler (D8) will rewrite your app's code to enable assertions at compile time, so you always have assertion checks active.

For more information: [AGP release notes](https://developer.android.com/studio/releases/gradle-plugin#behavior_changes)

`mProcessingThread` is set to null when onPause() is called, and `CameraSource.release()` is executed when `onDestroy()` is called on `MaterialBarcodeScannerActivity` which is causing a NullPointerException.
